### PR TITLE
Add support for ignoreList property

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -251,7 +251,14 @@ pub fn decode_regular(rsm: RawSourceMap) -> Result<SourceMap> {
         .sources_content
         .map(|x| x.into_iter().map(|v| v.map(Into::into)).collect::<Vec<_>>());
 
-    let mut sm = SourceMap::new(file, tokens, names, sources, source_content);
+    let mut sm = SourceMap::new(
+        file,
+        tokens,
+        names,
+        sources,
+        source_content,
+        rsm.ignore_list.unwrap_or_default(),
+    );
     sm.set_source_root(rsm.source_root);
     sm.set_debug_id(rsm.debug_id);
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -170,6 +170,11 @@ impl Encodable for SourceMap {
             names: Some(self.names().map(|x| Value::String(x.to_string())).collect()),
             range_mappings: serialize_range_mappings(self),
             mappings: Some(serialize_mappings(self)),
+            ignore_list: if self.ignore_list.is_empty() {
+                None
+            } else {
+                Some(self.ignore_list.clone())
+            },
             x_facebook_offsets: None,
             x_metro_module_paths: None,
             x_facebook_sources: None,
@@ -203,6 +208,7 @@ impl Encodable for SourceMapIndex {
             names: None,
             range_mappings: None,
             mappings: None,
+            ignore_list: None,
             x_facebook_offsets: None,
             x_metro_module_paths: None,
             x_facebook_sources: None,

--- a/src/jsontypes.rs
+++ b/src/jsontypes.rs
@@ -46,6 +46,8 @@ pub struct RawSourceMap {
     pub range_mappings: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mappings: Option<String>,
+    #[serde(rename = "ignoreList", skip_serializing_if = "Option::is_none")]
+    pub ignore_list: Option<Vec<u32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x_facebook_offsets: Option<Vec<Option<u32>>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/test_index.rs
+++ b/tests/test_index.rs
@@ -158,3 +158,50 @@ fn test_indexed_sourcemap_for_react_native() {
     let ism = SourceMapIndex::from_reader(input).unwrap();
     assert!(ism.is_for_ram_bundle());
 }
+
+#[test]
+fn test_flatten_indexed_sourcemap_with_ignore_list() {
+    let input: &[_] = br#"{
+        "version": 3,
+        "file": "bla",
+        "sections": [
+            {
+                "offset": {
+                    "line": 0,
+                    "column": 0
+                },
+                "map": {
+                    "version":3,
+                    "sources":["file1.js"],
+                    "names":["add","a","b"],
+                    "mappings":"AAAA,QAASA,KAAIC,EAAGC,GACf,YACA,OAAOD,GAAIC",
+                    "file":"file1.min.js"
+                }
+            },
+            {
+                "offset": {
+                    "line": 1,
+                    "column": 0
+                },
+                "map": {
+                    "version":3,
+                    "sources":["file2.js"],
+                    "names":["multiply","a","b","divide","add","c","e","Raven","captureException"],
+                    "mappings":"AAAA,QAASA,UAASC,EAAGC,GACpB,YACA,OAAOD,GAAIC,EAEZ,QAASC,QAAOF,EAAGC,GAClB,YACA,KACC,MAAOF,UAASI,IAAIH,EAAGC,GAAID,EAAGC,GAAKG,EAClC,MAAOC,GACRC,MAAMC,iBAAiBF",
+                    "file":"file2.min.js",
+                    "ignoreList": [0]
+                }
+            }
+        ]
+    }"#;
+
+    let ism = SourceMapIndex::from_reader(input).unwrap();
+    assert_eq!(
+        ism.flatten()
+            .unwrap()
+            .ignore_list()
+            .cloned()
+            .collect::<Vec<u32>>(),
+        vec![1]
+    );
+}


### PR DESCRIPTION
Sourcemaps can now specify an `ignoreList`, a list of indexes into sources for which those sources should be shown as ignored in dev tools, for example as collapsed stack frames in program stacks.

This adds the list to the SourceMap structure but only includes it in serialized output when it’s non-zero. Open to feedback.

Added a test to exercise this through flattening indexed source maps into a regular map with updated source positions.
